### PR TITLE
Added dark mode

### DIFF
--- a/downloads/index.html
+++ b/downloads/index.html
@@ -1,147 +1,217 @@
-<!DOCTYPE HTML>
+t<!DOCTYPE HTML>
 <html>
-	<head>
-		<title>Funkin' Song Converter</title>
-	</head>
-	<style>
-		body {
-			font-family: "Helvetica Neue", "Helvetica", Arial,sans-serif;
-		}
-		footer #credits {
-			text-decoration: none !important;
-			color: white;
-		}
-		img {
-			vertical-align: middle
-		}
-		#download {
-			vertical-align: top;
-			align-self: right;
-		}
-		h3 {
-			border-radius: 0.25em;
-			background-color: #4d97ff;
-			padding: 1em;
-			color: white;
-		}
-		.material-icons {
-			vertical-align: middle;
-		}
-		img {
-			padding: 1em;
-		}
-		.changelog-items li {
-			padding-top: 5px;
-		}
-		.code a {
-			font-family: "Consolas", sans-serif;
-		}
-		.tooltip {
-		  position: relative;
-		  display: inline-block;
-		  border-bottom: 1px dotted black;
-		}
+  <head>
+    <title>Funkin' Song Converter</title>
+  </head>
+  <style>
+    @media (prefers-color-scheme: light) {
+    body {
+      font-family: "Helvetica Neue", "Helvetica", Arial,sans-serif;
+    }
+    footer #credits {
+      text-decoration: none !important;
+      color: white;
+    }
+    img {
+      vertical-align: middle
+    }
+    #download {
+      vertical-align: top;
+      align-self: right;
+    }
+    h3 {
+      border-radius: 0.25em;
+      background-color: #4d97ff;
+      padding: 1em;
+      color: white;
+    }
+    .material-icons {
+      vertical-align: middle;
+    }
+    img {
+      padding: 1em;
+    }
+    .changelog-items li {
+      padding-top: 5px;
+    }
+    .code a {
+      font-family: "Consolas", sans-serif;
+    }
+    .tooltip {
+      position: relative;
+      display: inline-block;
+      border-bottom: 1px dotted black;
+    }
 
-		.tooltip .tooltiptext {
-		  visibility: hidden;
-		  background-color: black;
-		  color: #fff;
-		  width: 300%;
-		  text-align: center;
-		  border-radius: 6px;
-		  padding: 5px;
-		  
-		  /* Position the tooltip */
-		  position: absolute;
-		  z-index: 1;
-		  bottom: 100%;
-		  left: 0%;
-		}
+    .tooltip .tooltiptext {
+      visibility: hidden;
+      background-color: black;
+      color: #fff;
+      width: 300%;
+      text-align: center;
+      border-radius: 6px;
+      padding: 5px;
+      
+      /* Position the tooltip */
+      position: absolute;
+      z-index: 1;
+      bottom: 100%;
+      left: 0%;
+    }
 
-		.tooltip:hover .tooltiptext {
-		  visibility: visible;
-		}
-	</style>
-	<body>
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<link href="https://fonts.googleapis.com/icon?family=Material+Icons"
+    .tooltip:hover .tooltiptext {
+      visibility: visible;
+    }}
+    @media (prefers-color-scheme: dark) {
+    body {
+      font-family: "Helvetica Neue", "Helvetica", Arial,sans-serif;
+      background-image: linear-gradient(to bottom,#212121, #000000);
+    }
+    div {
+      color:white;
+    }
+    h2 {
+      color: white;
+    }
+    footer #credits {
+      text-decoration: none !important;
+      color: white;
+    }
+    img {
+      vertical-align: middle
+    }
+    #download {
+      vertical-align: top;
+      align-self: right;
+    }
+    h3 {
+      border-radius: 0.25em;
+      background-color: #4d97ff;
+      padding: 1em;
+      color: white;
+    }
+    .material-icons {
+      vertical-align: middle;
+    }
+    img {
+      padding: 1em;
+    }
+    .changelog-items li {
+      padding-top: 5px;
+    }
+    .code a {
+      font-family: "Consolas", sans-serif;
+    }
+    .tooltip {
+      position: relative;
+      display: inline-block;
+      border-bottom: 1px dotted white;
+    }
+
+    .tooltip .tooltiptext {
+      visibility: hidden;
+      background-color: black;
+      color: #fff;
+      width: 300%;
+      text-align: center;
+      border-radius: 6px;
+      padding: 5px;
+      
+      /* Position the tooltip */
+      position: absolute;
+      z-index: 1;
+      bottom: 100%;
+      left: 0%;
+    }
+
+    .tooltip:hover .tooltiptext {
+      visibility: visible;
+    }
+      a{
+      color: #1c7de6;
+      }
+  </style>
+<body>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet">
-		<div id="topBar" style="background-color: #4d97ff; width: 100%; height: 50px; align-items: center; display: flex; flex-direction: row; position:fixed; top: 0; left: 0">
-			<ul style="list-style: none; display: flex; flex-direction: row; align-items: center; padding-left:0">
-				<li class="heading" style="padding: 1em">
-					<a style="color: #ffffff; text-decoration: none; background-color: #0fbd8c; padding: 1em" href="https://cabalex.github.io"><b>cabalex.github.io</b></a>
-				</li>
-				<li>
-					<a href="https://scratch.mit.edu"><image src="https://scratch.mit.edu/images/logo_sm.png" height="40px"></image></a>
-				</li>
-				<li class="heading" style="padding: 1em">
-					<a style="color: #ffffff; text-decoration: none" href="https://cabalex.github.io/fnf-song-converter"><b>FNF Scratch song converter</b></a>
-				</li>
-			</ul>
-		</div>
-		<br></br>
-		<div id="warningNotice" style="display: none; background-color: #ff4d5c; padding: 1em; margin-top:4em; color: white; left:0; border-radius:0.25em">
-			Notice: My official Friday Night Funkin' Scratch project will no longer recieve updates or improvements due to circumstances beyond my control.
-			<br></br>
-			<a href="../takedown-info/index.html" style="text-decoration: none; color:black; padding:0.5em; background-color:white; margin-top: 3em; margin-bottom:1em; border-radius:0.25em">Read more</a></div>
-		<h2>Friday Night Funkin' Scratch Project Downloads</h2>
-		Take your pick on what project you want to download. <b>Unless you absolutely need Winter Horrorland, I recommend the latest version.</b>
-		<br>
-		<br>
-		<b><u>Remember: if you're not making any significant changes to the gameplay, please credit my work in the Notes and Credits section.</u></b> I spent a lot of time on it, and if you don't put it near the top, people won't see it. <b>Also, if you are directly reuploading my project, please don't modify my watermarks to add your own name.</b> I mean, if you're not making any changes, it seems kinda silly, right?
-		<br>
-		<i>Psst! You don't need to credit me if you're just remixing. Scratch credits me automatically! Don't worry about it :)</i>
-		<h3><span class="material-icons">upcoming</span> Download the latest version (v25v3)</h3>
-		<b><a href="https://drive.google.com/file/d/1XkLv45TGPpT5mYtXZPu2ofN3cwspYhIS/view?usp=sharing" style="text-decoration: none; color:white; padding:0.5em; background-color:#4d97ff; margin-top: 3em; margin-bottom:1em; border-radius:0.25em"><span class="material-icons">get_app</span> Download the .sb3 file</a> <a href="https://turbowarp.org/519325355/" style="text-decoration: none; color:white; padding:0.5em; background-color:#0fbd8c; margin-top: 3em; margin-bottom:1em; border-radius:0.25em"><span class="material-icons">sports_esports</span> Edit/download the file in Turbowarp</a> <a href="https://scratch.mit.edu/projects/519325355/" style="text-decoration: none; color:white; padding:0.5em; background-color:#F8AA36; margin-top: 3em; margin-bottom:1em; border-radius:0.25em"><span class="material-icons">sports_esports</span> Scratch reupload</a></b>
-		<br><br><span class="material-icons">warning</span> Getting errors when loading the project in Turbowarp? You may want to try <a href="https://forkphorus.github.io/#519325355">Forkphorus</a> instead.
-		<br><br><span class="material-icons">warning</span> Some school administrations may block you from downloading this file. Requesting permission won't work- try on a personal Google account.
-		<h3 style="background-color: #afafaf"><span class="material-icons">archive</span> Download the latest version with Winter Horrorland included (v7)</h3>
-		<b>This will no longer be updated!</b> While you can add back support manually, I will no longer be maintaining a version with Winter Horrorland included. <div class="tooltip">Here's why.<span class="tooltiptext">Since I really don't want to be banned off of Scratch, I've decided to take more precautions with the second release of my FNF project. I know people like the song, but I can't include it without serious takedown implications. Sorry!</span></div>
-		<br><br>
-		<b><a style="text-decoration: none; color:white; padding:0.5em; background-color:#afafaf; margin-top: 3em; margin-bottom:1em; border-radius:0.25em"><span class="material-icons">get_app</span> Download the .sb3 file (coming soon)</a> <a href="https://turbowarp.org/484321587/" style="text-decoration: none; color:white; padding:0.5em; background-color:#0fbd8c; margin-top: 3em; margin-bottom:1em; border-radius:0.25em"><span class="material-icons">sports_esports</span> Edit/download the file in Turbowarp</a></b>
-		<h3><span class="material-icons">inbox</span> Changelog</h3>
-		<ul class="changelog-items">
-			<li>v25v3 - Optimized note duplication prevention algorithm (thanks <a href="https://scratch.mit.edu/users/kris235">@kris235</a>!)</li>
-			<li>v25v2 - Fixed bug where local high scores were not updating on custom songs.</li>
-			<li>v25v1 - Censored some minor background elements in Week 5.</li>
-			<li>v25 (5/10/2021) - Overhaul of how songs are loaded. Also, fixed bug where high score would show in custom songs.</li>
-			<li>v24v2 (5/4/2021) - Miscellaneous bug fixes.</li>
-			<li>v24v1 (5/2/2021) - Changed Tankman's asset slightly.</li>
-			<li>v24 (5/1/2021) - Overhaul of how combos and misses work; fixed big bug where loading would occur out of order</li>
-			<li>v23v2 (4/27/2021) - Fixed scrolling in the settings menu.</li>
-			<li>v23v1 (4/27/2021) - Fixed bug where "danger" sprites didn't show up.</li>
-			<li>v23 (4/27/2021) - Overhaul of health bar.</li>
-			<li>v22 (4/26/2021) - Note and stage optimizations. Hopefully timings should be less off now?</li>
-			<li>v21v2 (4/24/2021) - Fixed mobile navigation on the menus.</li>
-			<li>v21v1 (4/24/2021) - Miscellaneous bug fixes.</li>
-			<li>v21 (4/24/2021) - New settings and donate menu! You can now configure the controls. Reduced Motion lets you play the game without all the move-y camera bits. Changed the "Misses" counter to "Accuracy", and added the top score for each song to the UI.</li>
-			<li>v20 (4/24/2021) - Huge camera update! Changed the "bop" system from the arrows/notes moving to the whole stage moving at once. Also, Week 7 should run a lot faster as I've optimized the clone count from 15 to 8.</li>
-			<li>v19 (4/22/2021) - Added note calibration! Press C in the menu to enter simple calibration, where you just need to tap to the beat to calibrate. Or, hold C to fine tune your calibration. Each number is a 100th of a second. This may not help in all cases (some computers may have inconsistent latency) but it should help for most.</li>
-			<li>v18 (4/22/2021) - Patched Week 5 to be more family friendly, I guess :)</li>
-			<li>v17 (4/22/2021) - Fixed some background things, and made note timing much more precise (apparently i wasn't checking note presses fast enough).</li>
-			<li>v16 (4/21/2021) - OKAY, I know I said I wouldn't do Week 7. Well, here we are. Updated menus and UI, improved performance, and Week 7, along with another re-release. I should stop promising I won't do things...</li>
-			<br>
-			<li>v15 (4/17/2021) - Added downscroll as a native feature! Toggle with Q in the menu.</li>
-			<li>v14 (3/29/2021) - Added a misses counter and local high scores- try to get perfect!</li>
-			<li>v13 (3/8/2021) - Fixed the bug on pixel songs where held notes didn't display properly. Also, figured I'd package this into a release.</li>
-			<li>v12v2 (3/7/2021) - Fixed ANOTHER giant bug with note detection (should actually work now?)</li>
-			<li>v12v1 (3/7/2021) - Fixed giant bug with note detection, whoops</li>
-			<li>v12 (3/7/2021) - fixed MASSIVE bug where more than one note could be hit at once, causing problems- combos are like... actually possible now (although there may be more lag)- also polished a few things</li>
-			<li>v11 (3/6/2021) - made the internals a bit more friendly to modding.</li>
-			<li>v10 (2/25/2021) - fixed held notes [finally]. It might lag a little more, but at least it's fixed</li>
-			<li>v9v2 (2/25/2021) - ALRIGHT FINE, I made the timing more lenient lol</li>
-			<li>v9v1 (2/23/2021) - fixed bug where you could get points by spamming the keys on held notes (thanks @friday_night_funkinF)</li>
-			<li>v9 (2/23/2021) - scoring systems! compete with the world to get the highest scores on all difficulties.</li>
-			<li>v8 (or i guess 2.0, 2/22/2021) - reuploaded back to Scratch! hopefully i'm actually not taken down this time. includes some improvements to gameplay, and also finishes off all the songs!</li>
-			<br>
-			<li>v7 (2/11/2021) - overhaul of how notes are counted as "hit" or "missed"! it now relies on the timer directly, so it should be more accurate (in most cases >:( )</li>
-			<li>v6 (2/11/2021) - added [most] of Week 6. I just have the spirit's sprites left, but I'll do that sometime soon. also fixed some bugs, but there's prob more</li>
-			<li>v5v1 - fixed bug where you could die in the menu (whoops, thanks @undertale_guy6394647); if you REALLY wanna experience it enable debug mode</li>
-			<li>v5 (2/10/2021) - Added Week 5 and a quirky warning for Winter Horrorland (v8 update: has been removed)</li>
-			<li>v4 (2/9/2021) - No internal changes, but it's now possible to convert songs from FNF! (See the READ ME sprite inside.)</li>
-			<li>v3 (2/9/2021) - you can now choose between different song difficulties. also i may have bloated this project 3x, whoops</li>
-			<li>v2 (2/9/2021) - added week 2 and 4. isn't that funky. also a lot of animations should be more in time now</li>
-			<li>v1 (2/8/2021) - i did it, i made the game. have fun playing weeks 1 and 3 because i am too lazy to do 2</li>
-		<br>
-	</body>
+    <div id="topBar" style="background-color: #4d97ff; width: 100%; height: 50px; align-items: center; display: flex; flex-direction: row; position:fixed; top: 0; left: 0">
+      <ul style="list-style: none; display: flex; flex-direction: row; align-items: center; padding-left:0">
+        <li class="heading" style="padding: 1em">
+          <a style="color: #ffffff; text-decoration: none; background-color: #0fbd8c; padding: 1em" href="https://cabalex.github.io"><b>cabalex.github.io</b></a>
+        </li>
+        <li>
+          <a href="https://scratch.mit.edu"><image src="https://scratch.mit.edu/images/logo_sm.png" height="40px"></image></a>
+        </li>
+        <li class="heading" style="padding: 1em">
+          <a style="color: #ffffff; text-decoration: none" href="https://cabalex.github.io/fnf-song-converter/"><b>FNF Scratch song converter</b></a>
+        </li>
+      </ul>
+    </div>
+    <br></br>
+    <div id="warningNotice" style="display: none; background-color: #ff4d5c; padding: 1em; margin-top:4em; color: white; left:0; border-radius:0.25em">
+      Notice: My official Friday Night Funkin' Scratch project will no longer recieve updates or improvements due to circumstances beyond my control.
+      <br></br>
+      <a href="../takedown-info/index.html" style="text-decoration: none; color:black; padding:0.5em; background-color:white; margin-top: 3em; margin-bottom:1em; border-radius:0.25em">Read more</a></div>
+    <h2>Friday Night Funkin' Scratch Project Downloads</h2>
+<div>  Take your pick on what project you want to download. <b>Unless you absolutely need Winter Horrorland, I recommend the latest version.</b>
+    <br>
+    <br>
+    <b><u>Remember: if you're not making any significant changes to the gameplay, please credit my work in the Notes and Credits section.</u></b> I spent a lot of time on it, and if you don't put it near the top, people won't see it. <b>Also, if you are directly reuploading my project, please don't modify my watermarks to add your own name.</b> I mean, if you're not making any changes, it seems kinda silly, right?
+    <br>
+    <i>Psst! You don't need to credit me if you're just remixing. Scratch credits me automatically! Don't worry about it :)</i>
+    <h3><span class="material-icons">upcoming</span> Download the latest version (v25v3)</h3>
+    <b><a href="https://drive.google.com/file/d/1XkLv45TGPpT5mYtXZPu2ofN3cwspYhIS/view?usp=sharing" style="text-decoration: none; color:white; padding:0.5em; background-color:#4d97ff; margin-top: 3em; margin-bottom:1em; border-radius:0.25em"><span class="material-icons">get_app</span> Download the .sb3 file</a> <a href="https://turbowarp.org/519325355/" style="text-decoration: none; color:white; padding:0.5em; background-color:#0fbd8c; margin-top: 3em; margin-bottom:1em; border-radius:0.25em"><span class="material-icons">sports_esports</span> Edit/download the file in Turbowarp</a> <a href="https://scratch.mit.edu/projects/519325355/" style="text-decoration: none; color:white; padding:0.5em; background-color:#F8AA36; margin-top: 3em; margin-bottom:1em; border-radius:0.25em"><span class="material-icons">sports_esports</span> Scratch reupload</a></b>
+    <br><br><span class="material-icons">warning</span> Getting errors when loading the project in Turbowarp? You may want to try <a href="https://forkphorus.github.io/#519325355">Forkphorus</a> instead.
+    <br><br><span class="material-icons">warning</span> Some school administrations may block you from downloading this file. Requesting permission won't work- try on a personal Google account.
+    <h3 style="background-color: #afafaf"><span class="material-icons">archive</span> Download the latest version with Winter Horrorland included (v7)</h3>
+    <b>This will no longer be updated!</b> While you can add back support manually, I will no longer be maintaining a version with Winter Horrorland included. <div class="tooltip">Here's why.<span class="tooltiptext">Since I really don't want to be banned off of Scratch, I've decided to take more precautions with the second release of my FNF project. I know people like the song, but I can't include it without serious takedown implications. Sorry!</span></div>
+    <br><br>
+    <b><a style="text-decoration: none; color:white; padding:0.5em; background-color:#afafaf; margin-top: 3em; margin-bottom:1em; border-radius:0.25em"><span class="material-icons">get_app</span> Download the .sb3 file (coming soon)</a> <a href="https://turbowarp.org/484321587/" style="text-decoration: none; color:white; padding:0.5em; background-color:#0fbd8c; margin-top: 3em; margin-bottom:1em; border-radius:0.25em"><span class="material-icons">sports_esports</span> Edit/download the file in Turbowarp</a></b>
+    <h3><span class="material-icons">inbox</span> Changelog</h3>
+    <ul class="changelog-items">
+      <li>v25v3 - Optimized note duplication prevention algorithm (thanks <a href="https://scratch.mit.edu/users/kris235">@kris235</a>!)</li>
+      <li>v25v2 - Fixed bug where local high scores were not updating on custom songs.</li>
+      <li>v25v1 - Censored some minor background elements in Week 5.</li>
+      <li>v25 (5/10/2021) - Overhaul of how songs are loaded. Also, fixed bug where high score would show in custom songs.</li>
+      <li>v24v2 (5/4/2021) - Miscellaneous bug fixes.</li>
+      <li>v24v1 (5/2/2021) - Changed Tankman's asset slightly.</li>
+      <li>v24 (5/1/2021) - Overhaul of how combos and misses work; fixed big bug where loading would occur out of order</li>
+      <li>v23v2 (4/27/2021) - Fixed scrolling in the settings menu.</li>
+      <li>v23v1 (4/27/2021) - Fixed bug where "danger" sprites didn't show up.</li>
+      <li>v23 (4/27/2021) - Overhaul of health bar.</li>
+      <li>v22 (4/26/2021) - Note and stage optimizations. Hopefully timings should be less off now?</li>
+      <li>v21v2 (4/24/2021) - Fixed mobile navigation on the menus.</li>
+      <li>v21v1 (4/24/2021) - Miscellaneous bug fixes.</li>
+      <li>v21 (4/24/2021) - New settings and donate menu! You can now configure the controls. Reduced Motion lets you play the game without all the move-y camera bits. Changed the "Misses" counter to "Accuracy", and added the top score for each song to the UI.</li>
+      <li>v20 (4/24/2021) - Huge camera update! Changed the "bop" system from the arrows/notes moving to the whole stage moving at once. Also, Week 7 should run a lot faster as I've optimized the clone count from 15 to 8.</li>
+      <li>v19 (4/22/2021) - Added note calibration! Press C in the menu to enter simple calibration, where you just need to tap to the beat to calibrate. Or, hold C to fine tune your calibration. Each number is a 100th of a second. This may not help in all cases (some computers may have inconsistent latency) but it should help for most.</li>
+      <li>v18 (4/22/2021) - Patched Week 5 to be more family friendly, I guess :)</li>
+      <li>v17 (4/22/2021) - Fixed some background things, and made note timing much more precise (apparently i wasn't checking note presses fast enough).</li>
+      <li>v16 (4/21/2021) - OKAY, I know I said I wouldn't do Week 7. Well, here we are. Updated menus and UI, improved performance, and Week 7, along with another re-release. I should stop promising I won't do things...</li>
+      <br>
+      <li>v15 (4/17/2021) - Added downscroll as a native feature! Toggle with Q in the menu.</li>
+      <li>v14 (3/29/2021) - Added a misses counter and local high scores- try to get perfect!</li>
+      <li>v13 (3/8/2021) - Fixed the bug on pixel songs where held notes didn't display properly. Also, figured I'd package this into a release.</li>
+      <li>v12v2 (3/7/2021) - Fixed ANOTHER giant bug with note detection (should actually work now?)</li>
+      <li>v12v1 (3/7/2021) - Fixed giant bug with note detection, whoops</li>
+      <li>v12 (3/7/2021) - fixed MASSIVE bug where more than one note could be hit at once, causing problems- combos are like... actually possible now (although there may be more lag)- also polished a few things</li>
+      <li>v11 (3/6/2021) - made the internals a bit more friendly to modding.</li>
+      <li>v10 (2/25/2021) - fixed held notes [finally]. It might lag a little more, but at least it's fixed</li>
+      <li>v9v2 (2/25/2021) - ALRIGHT FINE, I made the timing more lenient lol</li>
+      <li>v9v1 (2/23/2021) - fixed bug where you could get points by spamming the keys on held notes (thanks @friday_night_funkinF)</li>
+      <li>v9 (2/23/2021) - scoring systems! compete with the world to get the highest scores on all difficulties.</li>
+      <li>v8 (or i guess 2.0, 2/22/2021) - reuploaded back to Scratch! hopefully i'm actually not taken down this time. includes some improvements to gameplay, and also finishes off all the songs!</li>
+      <br>
+      <li>v7 (2/11/2021) - overhaul of how notes are counted as "hit" or "missed"! it now relies on the timer directly, so it should be more accurate (in most cases >:( )</li>
+      <li>v6 (2/11/2021) - added [most] of Week 6. I just have the spirit's sprites left, but I'll do that sometime soon. also fixed some bugs, but there's prob more</li>
+      <li>v5v1 - fixed bug where you could die in the menu (whoops, thanks @undertale_guy6394647); if you REALLY wanna experience it enable debug mode</li>
+      <li>v5 (2/10/2021) - Added Week 5 and a quirky warning for Winter Horrorland (v8 update: has been removed)</li>
+      <li>v4 (2/9/2021) - No internal changes, but it's now possible to convert songs from FNF! (See the READ ME sprite inside.)</li>
+      <li>v3 (2/9/2021) - you can now choose between different song difficulties. also i may have bloated this project 3x, whoops</li>
+      <li>v2 (2/9/2021) - added week 2 and 4. isn't that funky. also a lot of animations should be more in time now</li>
+      <li>v1 (2/8/2021) - i did it, i made the game. have fun playing weeks 1 and 3 because i am too lazy to do 2</li>
+  div  <
+    <br>
+  </body>
 </html>

--- a/guide/index.html
+++ b/guide/index.html
@@ -1,109 +1,147 @@
 <!DOCTYPE HTML>
 <html>
-	<head>
-		<title>Funkin' Song Converter</title>
-		<meta http-equiv="refresh" content="3; URL=https://github.com/cabalex/fnf-song-converter/wiki" />
-	</head>
-	<style>
-		body {
-			font-family: "Helvetica Neue", "Helvetica", Arial,sans-serif;
-		}
-		footer #credits {
-			text-decoration: none !important;
-			color: white;
-		}
-		img {
-			vertical-align: middle
-		}
-		#download {
-			vertical-align: top;
-			align-self: right;
-		}
-		h3 {
-			border-radius: 0.25em;
-			background-color: #4d97ff;
-			padding: 1em;
-			color: white;
-		}
-		.material-icons {
-			vertical-align: middle;
-		}
-		img {
-			padding: 1em;
-		}
-		.code a {
-			font-family: "Consolas", sans-serif;
-		}
-	</style>
-	<body>
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<link href="https://fonts.googleapis.com/icon?family=Material+Icons"
+  <head>
+    <title>Funkin' Song Converter</title>
+    <meta http-equiv="refresh" content="3; URL=https://github.com/cabalex/fnf-song-converter/wiki" />
+  </head>
+  <style>
+    @media (prefers-color-scheme: light) {
+    body {
+      font-family: "Helvetica Neue", "Helvetica", Arial,sans-serif;
+    }
+    footer #credits {
+      text-decoration: none !important;
+      color: white;
+    }
+    img {
+      vertical-align: middle
+    }
+    #download {
+      vertical-align: top;
+      align-self: right;
+    }
+    h3 {
+      border-radius: 0.25em;
+      background-color: #4d97ff;
+      padding: 1em;
+      color: white;
+    }
+    .material-icons {
+      vertical-align: middle;
+    }
+    img {
+      padding: 1em;
+    }
+    .code a {
+      font-family: "Consolas", sans-serif;
+    }}
+     @media (prefers-color-scheme: dark) {
+    body {
+      font-family: "Helvetica Neue", "Helvetica", Arial,sans-serif;
+      background-color:black;
+    }
+    footer #credits {
+      text-decoration: none !important;
+      color: white;
+    }
+    img {
+      vertical-align: middle
+    }
+    #download {
+      vertical-align: top;
+      align-self: right;
+    }
+    p{
+      color:white;
+    }
+    h2{
+      color:white;
+    }
+    h3 {
+      border-radius: 0.25em;
+      background-color: #4d97ff;
+      padding: 1em;
+      color: white;
+    }
+    .material-icons {
+      vertical-align: middle;
+    }
+    img {
+      padding: 1em;
+    }
+    .code a {
+      font-family: "Consolas", sans-serif;
+    }}
+  </style>
+  <body>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet">
-		<div id="topBar" style="background-color: #4d97ff; width: 100%; height: 50px; align-items: center; display: flex; flex-direction: row; position:fixed; top: 0; left: 0">
-			<ul style="list-style: none; display: flex; flex-direction: row; align-items: center; padding-left:0">
-				<li class="heading" style="padding: 1em">
-					<a style="color: #ffffff; text-decoration: none; background-color: #0fbd8c; padding: 1em" href="https://cabalex.github.io"><b>cabalex.github.io</b></a>
-				</li>
-				<li>
-					<a href="https://scratch.mit.edu"><image src="https://scratch.mit.edu/images/logo_sm.png" height="40px"></image></a>
-				</li>
-				<li class="heading" style="padding: 1em">
-					<a style="color: #ffffff; text-decoration: none" href="https://cabalex.github.io/fnf-song-converter"><b>FNF Scratch song converter</b></a>
-				</li>
-				<li class="heading" style="padding: 1em; background-color: #0068f9" onmouseover="this.style.background='#0056d0';" onmouseout="this.style.background='#0068f9';">
-					<a style="color: #ffffff; text-decoration: none" href="https://cabalex.github.io/fnf-song-converter/guide"><b>Guides</b></a>
-				</li>
-			</ul>
-		</div>
-		<div style="padding-top: 40px; margin-left: 10px;">
-			<h2>We've moved to a wiki on GitHub; you'll be redirected in a few seconds...</h2>
-			<p><i>Or if you're lazy like me, you can <a href="https://github.com/cabalex/fnf-song-converter/wiki">click here</a>...</i></p>
-			<br>
-			<i id="introText"></i>
-		</div>
-		<script type="text/javascript">
-			var elem = document.getElementById('introText')
-			introTexts = [
-				"Wanna make your song not custom? There's a hidden list in the Menus sprite that stores all non-custom songs.",
-				"Press 1 to refresh the Free Play High Scores, and if you changed the dev name, you can reset Cloud High Scores with it!",
-				"The IntroText list in the Menus sprite stores all intro text in two-line pairs!",
-				"Wanna die fast? Press R in game!",
-				"Downscroll used to be a hidden toggle hotkey before the settings menu was made.",
-				"The project was taken down twice for being inappropriate for Scratch!",
-				"Monster was originally in the game, before having to be removed due to Scratch guidelines. You can still find it in old remixes of the project!",
-				"You can find downloads to the latest version of the project on the Downloads page.",
-				"A Friday Night Funkin' Lite version was originally released, but was unshared due to the performance benefits being minimal.",
-				"I do more work than just Friday Night Funkin'! Check my GitHub.",
-				"The developer ran out of ideas for text to put here. How was your day?",
-				"Shoutouts to Tom Fulp!",
-				"Play the Newgrounds version and support the original game's developers!",
-				"Funk on!",
-				"You can also have queries in this url (e.g. https://cabalex.github.io/fnf-song-converter/guide?customsongs) to jump to your page quicker."
-			]
-			elem.innerHTML = introTexts[Math.floor(Math.random()*introTexts.length)]
-			// Detect queries (shortlinks to different guides)
-			if (location.search.includes("customsongs")) {
-				location.href = "https://github.com/cabalex/fnf-song-converter/wiki/Making-and-Importing-New-Songs"
-			}
-			if (location.search.includes("customcharacters")) {
-				location.href = "https://github.com/cabalex/fnf-song-converter/wiki/Making-New-Characters"
-			}
-			if (location.search.includes("custombf")) {
-				location.href = "https://github.com/cabalex/fnf-song-converter/wiki/Making-new-costumes-for-BF"
-			}
-			if (location.search.includes("customstages")) {
-				location.href = "https://github.com/cabalex/fnf-song-converter/wiki/Making-Custom-Stages"
-			}
-		</script>
-		<!--
-		<h2>Friday Night Funkin' Modding Guides</h2>
-		<h5>Stumble your way through my janky code no more!</h5>
-		Select a guide.
-		<a href="basic/index.html" style="text-decoration: none;"><h3 style="background-color: #0fbd8c"><span class="material-icons">library_music</span> 1 | Making/Importing songs</h3></a>
-		<a href="character/index.html" style="text-decoration: none;"><h3 style="background-color: #afafaf"><span class="material-icons">person_add</span> 2 | Adding new characters (coming soon)</h3></a>
-		<a style="text-decoration: none;"><h3 style="background-color: #afafaf"><span class="material-icons">person_add</span> 3 | Modding BF and GF (coming soon)</h3></a>
-		<a style="text-decoration: none;"><h3 style="background-color: #afafaf"><span class="material-icons">crop_original</span> 4 | Adding new environments (coming soon)</h3></a>
-		<br>
-		<a href="troubleshooting/index.html" style="text-decoration: none;"><h3 style="background-color: #ff4d5c"><span class="material-icons">report</span> Troubleshooting</h3></a>-->
-	</body>
+    <div id="topBar" style="background-color: #4d97ff; width: 100%; height: 50px; align-items: center; display: flex; flex-direction: row; position:fixed; top: 0; left: 0">
+      <ul style="list-style: none; display: flex; flex-direction: row; align-items: center; padding-left:0">
+        <li class="heading" style="padding: 1em">
+          <a style="color: #ffffff; text-decoration: none; background-color: #0fbd8c; padding: 1em" href="https://cabalex.github.io"><b>cabalex.github.io</b></a>
+        </li>
+        <li>
+          <a href="https://scratch.mit.edu"><image src="https://scratch.mit.edu/images/logo_sm.png" height="40px"></image></a>
+        </li>
+        <li class="heading" style="padding: 1em">
+          <a style="color: #ffffff; text-decoration: none" href="https://cabalex.github.io/fnf-song-converter"><b>FNF Scratch song converter</b></a>
+        </li>
+        <li class="heading" style="padding: 1em; background-color: #0068f9" onmouseover="this.style.background='#0056d0';" onmouseout="this.style.background='#0068f9';">
+          <a style="color: #ffffff; text-decoration: none" href="https://cabalex.github.io/fnf-song-converter/guide"><b>Guides</b></a>
+        </li>
+      </ul>
+    </div>
+    <div style="padding-top: 40px; margin-left: 10px;">
+      <h2>We've moved to a wiki on GitHub; you'll be redirected in a few seconds...</h2>
+      <p><i>Or if you're lazy like me, you can <a href="https://github.com/cabalex/fnf-song-converter/wiki">click here</a>...</i></p>
+      <br>
+      <i id="introText"></i>
+    </div>
+    <script style="color:white"type="text/javascript">
+      var elem = document.getElementById('introText')
+      introTexts = [
+        "Wanna make your song not custom? There's a hidden list in the Menus sprite that stores all non-custom songs.",
+        "Press 1 to refresh the Free Play High Scores, and if you changed the dev name, you can reset Cloud High Scores with it!",
+        "The IntroText list in the Menus sprite stores all intro text in two-line pairs!",
+        "Wanna die fast? Press R in game!",
+        "Downscroll used to be a hidden toggle hotkey before the settings menu was made.",
+        "The project was taken down twice for being inappropriate for Scratch!",
+        "Monster was originally in the game, before having to be removed due to Scratch guidelines. You can still find it in old remixes of the project!",
+        "You can find downloads to the latest version of the project on the Downloads page.",
+        "A Friday Night Funkin' Lite version was originally released, but was unshared due to the performance benefits being minimal.",
+        "I do more work than just Friday Night Funkin'! Check my GitHub.",
+        "The developer ran out of ideas for text to put here. How was your day?",
+        "Shoutouts to Tom Fulp!",
+        "Play the Newgrounds version and support the original game's developers!",
+        "Funk on!",
+        "You can also have queries in this url (e.g. https://cabalex.github.io/fnf-song-converter/guide?customsongs) to jump to your page quicker."
+      ]
+      elem.innerHTML = introTexts[Math.floor(Math.random()*introTexts.length)]
+      // Detect queries (shortlinks to different guides)
+      if (location.search.includes("customsongs")) {
+        location.href = "https://github.com/cabalex/fnf-song-converter/wiki/Making-and-Importing-New-Songs"
+      }
+      if (location.search.includes("customcharacters")) {
+        location.href = "https://github.com/cabalex/fnf-song-converter/wiki/Making-New-Characters"
+      }
+      if (location.search.includes("custombf")) {
+        location.href = "https://github.com/cabalex/fnf-song-converter/wiki/Making-new-costumes-for-BF"
+      }
+      if (location.search.includes("customstages")) {
+        location.href = "https://github.com/cabalex/fnf-song-converter/wiki/Making-Custom-Stages"
+      }
+    </script>
+    <!--
+    <h2>Friday Night Funkin' Modding Guides</h2>
+    <h5>Stumble your way through my janky code no more!</h5>
+    Select a guide.
+    <a href="basic/index.html" style="text-decoration: none;"><h3 style="background-color: #0fbd8c"><span class="material-icons">library_music</span> 1 | Making/Importing songs</h3></a>
+    <a href="character/index.html" style="text-decoration: none;"><h3 style="background-color: #afafaf"><span class="material-icons">person_add</span> 2 | Adding new characters (coming soon)</h3></a>
+    <a style="text-decoration: none;"><h3 style="background-color: #afafaf"><span class="material-icons">person_add</span> 3 | Modding BF and GF (coming soon)</h3></a>
+    <a style="text-decoration: none;"><h3 style="background-color: #afafaf"><span class="material-icons">crop_original</span> 4 | Adding new environments (coming soon)</h3></a>
+    <br>
+    <a href="troubleshooting/index.html" style="text-decoration: none;"><h3 style="background-color: #ff4d5c"><span class="material-icons">report</span> Troubleshooting</h3></a>-->
+  </body>
 </html>

--- a/guide/index.html
+++ b/guide/index.html
@@ -38,7 +38,7 @@
      @media (prefers-color-scheme: dark) {
     body {
       font-family: "Helvetica Neue", "Helvetica", Arial,sans-serif;
-      background-color:linear-gradient(to bottom,#212121, #000000);;
+      background-image:linear-gradient(to bottom,#212121, #000000);;
     }
     footer #credits {
       text-decoration: none !important;

--- a/guide/index.html
+++ b/guide/index.html
@@ -38,7 +38,7 @@
      @media (prefers-color-scheme: dark) {
     body {
       font-family: "Helvetica Neue", "Helvetica", Arial,sans-serif;
-      background-image:linear-gradient(to bottom,#212121, #000000);
+      background-color: #212121;
     }
     footer #credits {
       text-decoration: none !important;
@@ -102,7 +102,7 @@
       <br>
       <i id="introText"></i>
     </div>
-    <div><script style="color:white"type="text/javascript">
+    <div><script type="text/javascript">
       var elem = document.getElementById('introText')
       introTexts = [
         "Wanna make your song not custom? There's a hidden list in the Menus sprite that stores all non-custom songs.",

--- a/guide/index.html
+++ b/guide/index.html
@@ -38,7 +38,7 @@
      @media (prefers-color-scheme: dark) {
     body {
       font-family: "Helvetica Neue", "Helvetica", Arial,sans-serif;
-      background-image:linear-gradient(to bottom,#212121, #000000);;
+      background-image:linear-gradient(to bottom,#212121, #000000);
     }
     footer #credits {
       text-decoration: none !important;

--- a/guide/index.html
+++ b/guide/index.html
@@ -38,7 +38,7 @@
      @media (prefers-color-scheme: dark) {
     body {
       font-family: "Helvetica Neue", "Helvetica", Arial,sans-serif;
-      background-color:black;
+      background-color:linear-gradient(to bottom,#212121, #000000);;
     }
     footer #credits {
       text-decoration: none !important;

--- a/guide/index.html
+++ b/guide/index.html
@@ -63,6 +63,9 @@
       padding: 1em;
       color: white;
     }
+     div{
+       color:white;
+       }
     .material-icons {
       vertical-align: middle;
     }
@@ -99,7 +102,7 @@
       <br>
       <i id="introText"></i>
     </div>
-    <script style="color:white"type="text/javascript">
+    <div><script style="color:white"type="text/javascript">
       var elem = document.getElementById('introText')
       introTexts = [
         "Wanna make your song not custom? There's a hidden list in the Menus sprite that stores all non-custom songs.",
@@ -132,7 +135,7 @@
       if (location.search.includes("customstages")) {
         location.href = "https://github.com/cabalex/fnf-song-converter/wiki/Making-Custom-Stages"
       }
-    </script>
+    </script></div>
     <!--
     <h2>Friday Night Funkin' Modding Guides</h2>
     <h5>Stumble your way through my janky code no more!</h5>

--- a/index.html
+++ b/index.html
@@ -1,187 +1,207 @@
 <!DOCTYPE HTML>
 <html>
-	<head>
-		<title>Funkin' Song Converter</title>
-	</head>
-	<style>
+  <head>
+    <title>Funkin' Song Converter</title>
+  </head>
+  <style>
     @media (prefers-color-scheme: light) {
 body {
-			font-family: "Helvetica Neue", "Helvetica", Arial,sans-serif;
-		}
-		footer #credits {
-			text-decoration: none !important;
-			color: white;
-		}
-		img {
-			vertical-align: middle
-		}
-		#download {
-			vertical-align: top;
-			align-self: right;
-		}
-		#heading {
-			padding: 1em
-		}
-		#heading:hover {
-			background-color: #0068f9
-		}
-		#fileName {
-			width: 100%;
-			text-align: center;
-			background-color: #fafafa;
-			padding: 1em 1.25em;
-			margin: .5em;
-			border: 2px solid rgba(0, 0, 0, 0.2);
-			border-radius: 0.25rem;
-			transition: border 0.2s, filter 0.2s, margin 0.2s;
-			cursor: pointer;
-		}
-		#fileName:hover, #download:hover {
-			border: 4px solid rgba(0, 0, 0, 0.2);
-			filter: brightness(85%);
-			margin: calc(0.5em-4px);
-		}
-		#download {
-			display: block;
-			text-align: center;
-			border: 4px solid #0fbd8c; 
-			transition: border 0.2s, filter 0.2s, margin 0.2s ease-in-out;
-			font-weight: bold;
-			background-color: #0fbd8c;
-			color: white;
-			padding: 1em 1.25em;
-			border: 0;
-			border-radius: 0.25rem;
-			margin: 0.5em;
-			text-decoration: none
-		}
+      font-family: "Helvetica Neue", "Helvetica", Arial,sans-serif;
+    }
+    footer #credits {
+      text-decoration: none !important;
+      color: white;
+    }
+    img {
+      vertical-align: middle
+    }
+    #download {
+      vertical-align: top;
+      align-self: right;
+    }
+    #heading {
+      padding: 1em
+    }
+    #heading:hover {
+      background-color: #0068f9
+    }
+    #fileName {
+      width: 100%;
+      text-align: center;
+      background-color: #fafafa;
+      padding: 1em 1.25em;
+      margin: .5em;
+      border: 2px solid rgba(0, 0, 0, 0.2);
+      border-radius: 0.25rem;
+      transition: border 0.2s, filter 0.2s, margin 0.2s;
+      cursor: pointer;
+    }
+    #fileName:hover, #download:hover {
+      border: 4px solid rgba(0, 0, 0, 0.2);
+      filter: brightness(85%);
+      margin: calc(0.5em-4px);
+    }
+    #download {
+      display: block;
+      text-align: center;
+      border: 4px solid #0fbd8c; 
+      transition: border 0.2s, filter 0.2s, margin 0.2s ease-in-out;
+      font-weight: bold;
+      background-color: #0fbd8c;
+      color: white;
+      padding: 1em 1.25em;
+      border: 0;
+      border-radius: 0.25rem;
+      margin: 0.5em;
+      text-decoration: none
+    }
+    .link1{
+      font-size: 12px;
+      color: blue;
+      text-decoration: none;
+    }
+    .link2{
+      text-decoration: none;
+    }
 }
     @media (prefers-color-scheme: dark) {
-		body {
-			font-family: "Helvetica Neue", "Helvetica", Arial,sans-serif;
+    body {
+      font-family: "Helvetica Neue", "Helvetica", Arial,sans-serif;
       background-image: linear-gradient(to bottom,#212121, #000000);
-		}
+    }
     a {
       color: #288ffc;
     }
     div {
       color: white;
     }
-		footer #credits {
-			text-decoration: none !important;
-			color: white;
-		}
-		img {
-			vertical-align: middle
-		}
-		#download {
-			vertical-align: top;
-			align-self: right;
-		}
-		#heading {
-			padding: 1em
-		}
-		#heading:hover {
-			background-color: #0068f9
-		}
-		#fileName {
-			width: 100%;
-			text-align: center;
-			background-color: #fafafa;
-			padding: 1em 1.25em;
-			margin: .5em;
-			border: 2px solid rgba(0, 0, 0, 0.2);
-			border-radius: 0.25rem;
-			transition: border 0.2s, filter 0.2s, margin 0.2s;
-			cursor: pointer;
-		}
-		#fileName:hover, #download:hover {
-			border: 4px solid rgba(0, 0, 0, 0.2);
-			filter: brightness(85%);
-			margin: calc(0.5em-4px);
-		}
-		#download {
-			display: block;
-			text-align: center;
-			border: 4px solid #0fbd8c; 
-			transition: border 0.2s, filter 0.2s, margin 0.2s ease-in-out;
-			font-weight: bold;
-			background-color: #0fbd8c;
-			color: white;
-			padding: 1em 1.25em;
-			border: 0;
-			border-radius: 0.25rem;
-			margin: 0.5em;
-			text-decoration: none
-		}
-        }
-	</style>
-	<body>
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<div id="topBar" style="background-color: #4d97ff; width: 100%; height: 50px; align-items: center; display: flex; flex-direction: row; position:fixed; top: 0; left: 0">
-			<ul style="list-style: none; display: flex; flex-direction: row; align-items: center; padding-left:0">
-				<li class="heading" style="padding: 1em">
-					<a style="color: #ffffff; text-decoration: none; background-color: #0fbd8c; padding: 1em" href="https://cabalex.github.io"><b>cabalex.github.io</b></a>
-				</li>
-				<li>
-					<a href="https://scratch.mit.edu"><image src="https://scratch.mit.edu/images/logo_sm.png" height="40px"></image></a>
-				</li>
-				<li class="heading" style="padding: 1em">
-					<a style="color: #ffffff; text-decoration: none" href="https://scratch.mit.edu/projects/519325355/"><b>FNF Scratch song converter</b></a>
-				</li>
-				<a style="color: #ffffff; text-decoration: none" href="guide/"><li class="heading" style="padding: 1em; background-color: #0068f9" onmouseover="this.style.background='#0056d0';" onmouseout="this.style.background='#0068f9';">
-					<b>Wanna make a song? Start here!</b>
-				</li></a>
-				<a style="color: #ffffff; text-decoration: none" href="downloads/"><li class="heading" style="padding: 1em; background-color: #4d97ff" onmouseover="this.style.background='#0068f9';" onmouseout="this.style.background='#4d97ff';">
-					<b>Downloads</b>
-				</li></a>
+    footer #credits {
+      text-decoration: none !important;
+      color: white;
+    }
+    img {
+      vertical-align: middle
+    }
+    #download {
+      vertical-align: top;
+      align-self: right;
+    }
+    #heading {
+      padding: 1em
+    }
+    #heading:hover {
+      background-color: #0068f9
+    }
+    #fileName {
+      width: 100%;
+      text-align: center;
+      background-color: #fafafa;
+      padding: 1em 1.25em;
+      margin: .5em;
+      border: 2px solid rgba(0, 0, 0, 0.2);
+      border-radius: 0.25rem;
+      transition: border 0.2s, filter 0.2s, margin 0.2s;
+      cursor: pointer;
+    }
+    #fileName:hover, #download:hover {
+      border: 4px solid rgba(0, 0, 0, 0.2);
+      filter: brightness(85%);
+      margin: calc(0.5em-4px);
+    }
+    #download {
+      display: block;
+      text-align: center;
+      border: 4px solid #0fbd8c; 
+      transition: border 0.2s, filter 0.2s, margin 0.2s ease-in-out;
+      font-weight: bold;
+      background-color: #0fbd8c;
+      color: white;
+      padding: 1em 1.25em;
+      border: 0;
+      border-radius: 0.25rem;
+      margin: 0.5em;
+      text-decoration: none
+    }
+        .link1{
+      font-size: 12px;
+      color: #288ffc;
+      text-decoration: none;
+    }
+    a{
+      color: #1c7de6;
+    }
+    .link2{
+      color: #1c7de6;
+      text-decoration: none;
+    }
+    }
+  </style>
+  <body>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <div id="topBar" style="background-color: #4d97ff; width: 100%; height: 50px; align-items: center; display: flex; flex-direction: row; position:fixed; top: 0; left: 0">
+      <ul style="list-style: none; display: flex; flex-direction: row; align-items: center; padding-left:0">
+        <li class="heading" style="padding: 1em">
+          <a style="color: #ffffff; text-decoration: none; background-color: #0fbd8c; padding: 1em" href="https://cabalex.github.io"><b>cabalex.github.io</b></a>
+        </li>
+        <li>
+          <a href="https://scratch.mit.edu"><image src="https://scratch.mit.edu/images/logo_sm.png" height="40px"></image></a>
+        </li>
+        <li class="heading" style="padding: 1em">
+          <a style="color: #ffffff; text-decoration: none" href="https://scratch.mit.edu/projects/519325355/"><b>FNF Scratch song converter</b></a>
+        </li>
+        <a style="color: #ffffff; text-decoration: none" href="guide/"><li class="heading" style="padding: 1em; background-color: #0068f9" onmouseover="this.style.background='#0056d0';" onmouseout="this.style.background='#0068f9';">
+          <b>Wanna make a song? Start here!</b>
+        </li></a>
+        <a style="color: #ffffff; text-decoration: none" href="downloads/"><li class="heading" style="padding: 1em; background-color: #4d97ff" onmouseover="this.style.background='#0068f9';" onmouseout="this.style.background='#4d97ff';">
+          <b>Downloads</b>
+        </li></a>
  
-		</div>
-		<div id="warningNotice" style="background-color: #ff4d5c; padding: 1em; margin-top:4em; color: white; left:0; border-radius:0.25em;">
-			<b>Funk on!</b> My project will probably no longer recieve substantial updates, but everything will continue to work as normal. Wanna see what I'm doing next? <a style="color: white; font-weight: bold" href="https://cabalex.github.io">Visit my homepage.</a>
-		</div>
-		<br>
-		<form>
-			<div style="width: 90%; padding-bottom: 20px; max-width: 500px; flex-direction: row; justify-content: left; flex-wrap: wrap; display: flex; background-color: rgba(77, 151, 255, 0.25); align-items: center; border-radius: 0.25rem; padding: 0 0.5em">
-				<p>
-					Expanded note handling (e.g. Tricky Mod Halo notes): <select name="noteHandlingSelector" id="noteHandlingSelector">
-						<option value="ignore">Ignore unexpected notes</option>
-						<option value="modulo">Limit to default range (0-7)</option>
-						<option value="expanded">Allow all notes (EXPERIMENTAL)</option>
-						<option value="expanded_unmodified">Allow all notes without modifications (EXPERIMENTAL)</option>
-				</select><br><a style="font-size: 12px; color: #288ffc; text-decoration: none;" href="https://github.com/cabalex/fnf-song-converter/wiki/Making-and-Importing-New-Songs#step-2--converting-your-song-map">What does this mean?</a></p>
-				<p style="color:black" id="fileName" onclick="getFile()" ondrop="dropHandler(event);" ondragover="dragOverHandler(event);">Upload your file...</p>
-				</div>
-		  </div>
-			<div style='height: 0px;width: 0px; overflow:hidden;'><input type="file" accept=".json", id="fileInput", onchange="fileLoad(event)"></div>
-		</form>
-		<div id="output" style="width: 90%; max-width: 500px; flex-direction: row; justify-content: left; flex-wrap: wrap; display: flex; background-color: rgba(77, 151, 255, 0.25); align-items: center; border-radius: 0.25rem; padding:0.5em; margin:0.5em 0; display: none;"></div>
-		<div style="padding-top: 2em; padding-bottom: 2em; padding-left: 1em; padding-right: 1em">
-			Convert your songs made in the Friday Night Funkin' Editor to song maps that the Scratch program can read. Nothing is sent or stored on any server- it's just Javascript and it runs directly in your (modern-ish) browser.
-			<h2><a style="color: #1c7de6; text-decoration: none" href="guide/">See the guide here for more info</a></h2>
-			<h3>Where do I get my JSON files?</h3>
-			Your JSON files are created in the official <a href="https://ninja-muffin24.itch.io/funkin">Friday Night Funkin'</a> beat map editor. When you load up the game, choose a song. Then, in that song, press 7. You'll then see the editor! <a href="https://www.youtube.com/watch?v=BstyEfnXdKM">There's plenty of guides on YouTube about how to use it</a>, so I won't talk about it here.
-			<br>When you're done with your song's beat map, go to the third tab and click "Save...". It should download a JSON to your computer. There it is!</br>
-			<h3>What do I do with the TXT file I just downloaded?</h3>
-			You can use it in <a href="https://scratch.mit.edu/projects/491440657/">the project</a>, of course! <a href="https://github.com/cabalex/fnf-song-converter/wiki/Making-and-Importing-New-Songs">See here for more info</a>.
-			<h3>What does the song speed do? The Scratch program doesn't ask for it.</h3>
-			The song speed parameter is related to the "multiplier" parameter that is set in the Scratch project, but they are definitely not interchangable. The multiplier variable also goes from high to low, instead of low to high. Play around with the variable settings and see what speed fits your song!
-			<br>It can be used as a reference to set the multiplier value, though.</br>
-			<h3>Can I convert my Scratch songs back to a FNF compatible JSON?</h3>
-			Unfortunately not. It technically is possible, but the converter trims out unnecessary info that isn't needed for the Scratch project, but is needed for the actual game (e.g. song name, song speed).
-			<h3>The download button didn't show up / I can't upload / I need help</h3>
-			Your beat map may be invalid, or you might just not be using a modern enough browser. Try opening the web console (CTRL+SHIFT+J on Chrome), and sending the error (and the beat map you tried to convert) to me.
-			<h3>Why isn't this a project on Scratch? I can't access this site on my computer/school owned device.</h3>
-			I can't really make an easy file converter in Scratch- it'd just be a mess. This way was just a lot easier, and allows me to add a bunch of other stuff too, like guides, and have it be all in one place. It's also easier to get errors troubleshooted and fixed here- just <a href="https://github.com/cabalex/fnf-song-converter/issues">open an issue</a> (bugs ONLY, no help requests).
-		</div>
-		<div style="height:5em"></div>
-		<script src="convert.js"></script>
-		<noscript>I'm not sure how you expect this to work without JS lol</noscript>
-		<footer style="position: fixed; bottom: 0; width:100%; left: 0;">
-			<div style="bottom: 0; background-color: #4d97ff; padding:1em; color:white;">
-				<b>code and ""reverse engineering"" by cabalex <a href="https://github.com/cabalex"><svg height="20px" style="color: white; align-items: middle;" viewBox="0 0 16 16" version="1.1" height="20px" aria-hidden="true"><path fill="white" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path></svg></a> <a id="credits" href="https://scratch.mit.edu/users/cabalex/"><image height="20px" src="https://u.cubeupload.com/csf30816/5aVuDN.png"></image></a></b>
-				<br><i>sick game devs: <a id="credits" href="https://twitter.com/ninja_muffin99">@ninja_muffin99</a>, <a id="credits" href="https://twitter.com/PhantomArcade3k">@PhantomArcade3k</a>, <a id="credits" href="https://twitter.com/evilsk8r">@evilsk8r</a>, and <a id="credits" href=https://twitter.com/kawaisprite>@kawaisprite</a></i></br>
-			</div>
-		</footer>
-	</body>
+    </div>
+    <div id="warningNotice" style="background-color: #ff4d5c; padding: 1em; margin-top:4em; color: white; left:0; border-radius:0.25em;">
+      <b>Funk on!</b> My project will probably no longer recieve substantial updates, but everything will continue to work as normal. Wanna see what I'm doing next? <a style="color: white; font-weight: bold" href="https://cabalex.github.io">Visit my homepage.</a>
+    </div>
+    <br>
+    <form>
+      <div style="width: 90%; padding-bottom: 20px; max-width: 500px; flex-direction: row; justify-content: left; flex-wrap: wrap; display: flex; background-color: rgba(77, 151, 255, 0.25); align-items: center; border-radius: 0.25rem; padding: 0 0.5em">
+        <p>
+          Expanded note handling (e.g. Tricky Mod Halo notes): <select name="noteHandlingSelector" id="noteHandlingSelector">
+            <option value="ignore">Ignore unexpected notes</option>
+            <option value="modulo">Limit to default range (0-7)</option>
+            <option value="expanded">Allow all notes (EXPERIMENTAL)</option>
+            <option value="expanded_unmodified">Allow all notes without modifications (EXPERIMENTAL)</option>
+        </select><br><a class="link1" href="https://github.com/cabalex/fnf-song-converter/wiki/Making-and-Importing-New-Songs#step-2--converting-your-song-map">What does this mean?</a></p>
+        <p style="color:black" id="fileName" onclick="getFile()" ondrop="dropHandler(event);" ondragover="dragOverHandler(event);">Upload your file...</p>
+        </div>
+      </div>
+      <div style='height: 0px;width: 0px; overflow:hidden;'><input type="file" accept=".json", id="fileInput", onchange="fileLoad(event)"></div>
+    </form>
+    <div id="output" style="width: 90%; max-width: 500px; flex-direction: row; justify-content: left; flex-wrap: wrap; display: flex; background-color: rgba(77, 151, 255, 0.25); align-items: center; border-radius: 0.25rem; padding:0.5em; margin:0.5em 0; display: none;"></div>
+    <div style="padding-top: 2em; padding-bottom: 2em; padding-left: 1em; padding-right: 1em">
+      Convert your songs made in the Friday Night Funkin' Editor to song maps that the Scratch program can read. Nothing is sent or stored on any server- it's just Javascript and it runs directly in your (modern-ish) browser.
+      <h2><a class="link2" href="guide/">See the guide here for more info</a></h2>
+      <h3>Where do I get my JSON files?</h3>
+      Your JSON files are created in the official <a href="https://ninja-muffin24.itch.io/funkin">Friday Night Funkin'</a> beat map editor. When you load up the game, choose a song. Then, in that song, press 7. You'll then see the editor! <a href="https://www.youtube.com/watch?v=BstyEfnXdKM">There's plenty of guides on YouTube about how to use it</a>, so I won't talk about it here.
+      <br>When you're done with your song's beat map, go to the third tab and click "Save...". It should download a JSON to your computer. There it is!</br>
+      <h3>What do I do with the TXT file I just downloaded?</h3>
+      You can use it in <a href="https://scratch.mit.edu/projects/491440657/">the project</a>, of course! <a href="https://github.com/cabalex/fnf-song-converter/wiki/Making-and-Importing-New-Songs">See here for more info</a>.
+      <h3>What does the song speed do? The Scratch program doesn't ask for it.</h3>
+      The song speed parameter is related to the "multiplier" parameter that is set in the Scratch project, but they are definitely not interchangable. The multiplier variable also goes from high to low, instead of low to high. Play around with the variable settings and see what speed fits your song!
+      <br>It can be used as a reference to set the multiplier value, though.</br>
+      <h3>Can I convert my Scratch songs back to a FNF compatible JSON?</h3>
+      Unfortunately not. It technically is possible, but the converter trims out unnecessary info that isn't needed for the Scratch project, but is needed for the actual game (e.g. song name, song speed).
+      <h3>The download button didn't show up / I can't upload / I need help</h3>
+      Your beat map may be invalid, or you might just not be using a modern enough browser. Try opening the web console (CTRL+SHIFT+J on Chrome), and sending the error (and the beat map you tried to convert) to me.
+      <h3>Why isn't this a project on Scratch? I can't access this site on my computer/school owned device.</h3>
+      I can't really make an easy file converter in Scratch- it'd just be a mess. This way was just a lot easier, and allows me to add a bunch of other stuff too, like guides, and have it be all in one place. It's also easier to get errors troubleshooted and fixed here- just <a href="https://github.com/cabalex/fnf-song-converter/issues">open an issue</a> (bugs ONLY, no help requests).
+    </div>
+    <div style="height:5em"></div>
+    <script src="convert.js"></script>
+    <noscript>I'm not sure how you expect this to work without JS lol</noscript>
+    <footer style="position: fixed; bottom: 0; width:100%; left: 0;">
+      <div style="bottom: 0; background-color: #4d97ff; padding:1em; color:white;">
+        <b>code and ""reverse engineering"" by cabalex <a href="https://github.com/cabalex"><svg height="20px" style="color: white; align-items: middle;" viewBox="0 0 16 16" version="1.1" height="20px" aria-hidden="true"><path fill="white" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path></svg></a> <a id="credits" href="https://scratch.mit.edu/users/cabalex/"><image height="20px" src="https://u.cubeupload.com/csf30816/5aVuDN.png"></image></a></b>
+        <br><i>sick game devs: <a id="credits" href="https://twitter.com/ninja_muffin99">@ninja_muffin99</a>, <a id="credits" href="https://twitter.com/PhantomArcade3k">@PhantomArcade3k</a>, <a id="credits" href="https://twitter.com/evilsk8r">@evilsk8r</a>, and <a id="credits" href=https://twitter.com/kawaisprite>@kawaisprite</a></i></br>
+      </div>
+    </footer>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
 		<title>Funkin' Song Converter</title>
 	</head>
 	<style>
-		body {
+    @media (prefers-color-scheme: light) {
+body {
 			font-family: "Helvetica Neue", "Helvetica", Arial,sans-serif;
 		}
 		footer #credits {
@@ -54,6 +55,66 @@
 			margin: 0.5em;
 			text-decoration: none
 		}
+}
+    @media (prefers-color-scheme: dark) {
+		body {
+			font-family: "Helvetica Neue", "Helvetica", Arial,sans-serif;
+      background-image: linear-gradient(to bottom,#212121, #000000);
+		}
+    a {
+      color: #288ffc;
+    }
+    div {
+      color: white;
+    }
+		footer #credits {
+			text-decoration: none !important;
+			color: white;
+		}
+		img {
+			vertical-align: middle
+		}
+		#download {
+			vertical-align: top;
+			align-self: right;
+		}
+		#heading {
+			padding: 1em
+		}
+		#heading:hover {
+			background-color: #0068f9
+		}
+		#fileName {
+			width: 100%;
+			text-align: center;
+			background-color: #fafafa;
+			padding: 1em 1.25em;
+			margin: .5em;
+			border: 2px solid rgba(0, 0, 0, 0.2);
+			border-radius: 0.25rem;
+			transition: border 0.2s, filter 0.2s, margin 0.2s;
+			cursor: pointer;
+		}
+		#fileName:hover, #download:hover {
+			border: 4px solid rgba(0, 0, 0, 0.2);
+			filter: brightness(85%);
+			margin: calc(0.5em-4px);
+		}
+		#download {
+			display: block;
+			text-align: center;
+			border: 4px solid #0fbd8c; 
+			transition: border 0.2s, filter 0.2s, margin 0.2s ease-in-out;
+			font-weight: bold;
+			background-color: #0fbd8c;
+			color: white;
+			padding: 1em 1.25em;
+			border: 0;
+			border-radius: 0.25rem;
+			margin: 0.5em;
+			text-decoration: none
+		}
+        }
 	</style>
 	<body>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -74,6 +135,7 @@
 				<a style="color: #ffffff; text-decoration: none" href="downloads/"><li class="heading" style="padding: 1em; background-color: #4d97ff" onmouseover="this.style.background='#0068f9';" onmouseout="this.style.background='#4d97ff';">
 					<b>Downloads</b>
 				</li></a>
+ 
 		</div>
 		<div id="warningNotice" style="background-color: #ff4d5c; padding: 1em; margin-top:4em; color: white; left:0; border-radius:0.25em;">
 			<b>Funk on!</b> My project will probably no longer recieve substantial updates, but everything will continue to work as normal. Wanna see what I'm doing next? <a style="color: white; font-weight: bold" href="https://cabalex.github.io">Visit my homepage.</a>
@@ -87,8 +149,8 @@
 						<option value="modulo">Limit to default range (0-7)</option>
 						<option value="expanded">Allow all notes (EXPERIMENTAL)</option>
 						<option value="expanded_unmodified">Allow all notes without modifications (EXPERIMENTAL)</option>
-				</select><br><a style="font-size: 12px; color: blue; text-decoration: none;" href="https://github.com/cabalex/fnf-song-converter/wiki/Making-and-Importing-New-Songs#step-2--converting-your-song-map">What does this mean?</a></p>
-				<p id="fileName" onclick="getFile()" ondrop="dropHandler(event);" ondragover="dragOverHandler(event);">Upload your file...</p>
+				</select><br><a style="font-size: 12px; color: #288ffc; text-decoration: none;" href="https://github.com/cabalex/fnf-song-converter/wiki/Making-and-Importing-New-Songs#step-2--converting-your-song-map">What does this mean?</a></p>
+				<p style="color:black" id="fileName" onclick="getFile()" ondrop="dropHandler(event);" ondragover="dragOverHandler(event);">Upload your file...</p>
 				</div>
 		  </div>
 			<div style='height: 0px;width: 0px; overflow:hidden;'><input type="file" accept=".json", id="fileInput", onchange="fileLoad(event)"></div>
@@ -96,7 +158,7 @@
 		<div id="output" style="width: 90%; max-width: 500px; flex-direction: row; justify-content: left; flex-wrap: wrap; display: flex; background-color: rgba(77, 151, 255, 0.25); align-items: center; border-radius: 0.25rem; padding:0.5em; margin:0.5em 0; display: none;"></div>
 		<div style="padding-top: 2em; padding-bottom: 2em; padding-left: 1em; padding-right: 1em">
 			Convert your songs made in the Friday Night Funkin' Editor to song maps that the Scratch program can read. Nothing is sent or stored on any server- it's just Javascript and it runs directly in your (modern-ish) browser.
-			<h2><a style="color: blue; text-decoration: none" href="https://cabalex.github.io/fnf-song-converter/guide/">See the guide here for more info</a></h2>
+			<h2><a style="color: #1c7de6; text-decoration: none" href="guide/">See the guide here for more info</a></h2>
 			<h3>Where do I get my JSON files?</h3>
 			Your JSON files are created in the official <a href="https://ninja-muffin24.itch.io/funkin">Friday Night Funkin'</a> beat map editor. When you load up the game, choose a song. Then, in that song, press 7. You'll then see the editor! <a href="https://www.youtube.com/watch?v=BstyEfnXdKM">There's plenty of guides on YouTube about how to use it</a>, so I won't talk about it here.
 			<br>When you're done with your song's beat map, go to the third tab and click "Save...". It should download a JSON to your computer. There it is!</br>

--- a/takedown-info/index.html
+++ b/takedown-info/index.html
@@ -1,105 +1,160 @@
 <!DOCTYPE HTML>
 <html>
-	<head>
-		<title>Funkin' Takedown Notice</title>
-	</head>
-	<style>
-		body {
-			font-family: "Helvetica Neue", "Helvetica", Arial,sans-serif;
-		}
-		footer #credits {
-			text-decoration: none !important;
-			color: white;
-		}
-		img {
-			vertical-align: middle
-		}
-		#download {
-			vertical-align: top;
-			align-self: right;
-		}
-		.banner-outer .banner-danger {
-			background-color: rgba(244, 157, 37, 0.25);
-			color: #ff8c1a;
-			left: 0;
-			margin: 0;
-			width: 99%;
-		}
-		.banner-outer {
-			display: flex;
-			left: 0;
-			padding: 1em;
-			background-color: rgba(244, 157, 37, 0.25);
-			color: #ff8c1a;
-			font-weight: bold;
-			margin: 0;
-		}
-		.banner-text {
-			padding-top: 1em;
-			left: 0;
-			margin: 0;
-			text-align: center;
-		}
-		.material-icons {
-			vertical-align: middle;
-		}
-	</style>
-	<body>
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<link href="https://fonts.googleapis.com/icon?family=Material+Icons"
+  <head>
+    <title>Funkin' Takedown Notice</title>
+  </head>
+  <style>
+    @media (prefers-color-scheme: light) {
+    body {
+      font-family: "Helvetica Neue", "Helvetica", Arial,sans-serif;
+    }
+    footer #credits {
+      text-decoration: none !important;
+      color: white;
+    }
+    img {
+      vertical-align: middle
+    }
+    #download {
+      vertical-align: top;
+      align-self: right;
+    }
+    .banner-outer .banner-danger {
+      background-color: rgba(244, 157, 37, 0.25);
+      color: #ff8c1a;
+      left: 0;
+      margin: 0;
+      width: 99%;
+    }
+    .banner-outer {
+      display: flex;
+      left: 0;
+      padding: 1em;
+      background-color: rgba(244, 157, 37, 0.25);
+      color: #ff8c1a;
+      font-weight: bold;
+      margin: 0;
+    }
+    .banner-text {
+      padding-top: 1em;
+      left: 0;
+      margin: 0;
+      text-align: center;
+    }
+    .material-icons {
+      vertical-align: middle;
+    }}
+    @media (prefers-color-scheme: dark) {
+    body {
+      font-family: "Helvetica Neue", "Helvetica", Arial,sans-serif;
+      background-image: linear-gradient(to bottom,#212121, #000000);
+    }
+    footer #credits {
+      text-decoration: none !important;
+      color: white;
+    }
+    div{
+      color: white;
+    }
+    i {
+      color: white;
+    }
+    h3 {
+      color: white;
+      }
+    img {
+      vertical-align: middle
+    }
+    #download {
+      vertical-align: top;
+      align-self: right;
+    }
+    .banner-outer .banner-danger {
+      background-color: rgba(244, 157, 37, 0.25);
+      color: #ff8c1a;
+      left: 0;
+      margin: 0;
+      width: 99%;
+    }
+    .banner-outer {
+      display: flex;
+      left: 0;
+      padding: 1em;
+      background-color: rgba(244, 157, 37, 0.25);
+      color: #ff8c1a;
+      font-weight: bold;
+      margin: 0;
+    }
+    .banner-text {
+      padding-top: 1em;
+      left: 0;
+      margin: 0;
+      text-align: center;
+    }
+    .material-icons {
+      vertical-align: middle;
+    }
+     a{
+      color: #1c7de6;
+      }
+    }
+  </style>
+  <body>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet">
-		<div id="topBar" style="background-color: #4d97ff; width: 100%; height: 50px; align-items: center; display: flex; flex-direction: row; position:fixed; top: 0; left: 0">
-			<ul style="list-style: none; display: flex; flex-direction: row; align-items: center; padding-left:0">
-				<li class="heading" style="padding: 1em">
-					<a style="color: #ffffff; text-decoration: none; background-color: #0fbd8c; padding: 1em" href="https://cabalex.github.io"><b>cabalex.github.io</b></a>
-				</li>
-				<li>
-					<a href="https://scratch.mit.edu"><image src="https://scratch.mit.edu/images/logo_sm.png" height="40px"></image></a>
-				</li>
-				<li class="heading" style="padding: 1em">
-					<a style="color: #ffffff; text-decoration: none" href="https://cabalex.github.io/fnf-song-converter"><b>FNF Scratch song converter</b></a>
-				</li>
-		</div>
-		<br></br>
-		<br></br>
-		<div class="banner-outer banner-danger"><div class="flex-row inner banner-inner"><span class="banner-text"><span>Your Scratch account has been temporarily blocked for resharing a censored project without making changes to ensure it follows the Community Guidelines. When your project was censored, you received a notification from the Scratch Team describing what aspects of the project broke our Community Guidelines. It is important to make changes to ensure to follows the Community Guidelines before resharing. Please read the Community Guidelines below for more information. Your account will be automatically unblocked on March 22, 2021, 4:03 p.m.<br><br>For project Friday Night Funkin':<br><br>The Scratch Team has removed this project because it is inappropriate for the Scratch website. Scratch is for kids ages 8 and up, so it's important that everything shared is appropriate for all ages. - March 19, 2021, 3:21 p.m.</span></span></div></div>
-		<div style="padding-top: 1em; padding-bottom: 2em; padding-left: 1em; padding-right: 1em">
-			<h3 style="text-decoration: none; color:white; padding:0.5em; background-color:#ef4d5c; margin-top: 3em; margin-bottom:1em; border-radius:0.25em"><span class="material-icons">warning</span> For now, <u>all plans to continue development of the base game and additional mods have been cancelled/put on hold.</u> I will no longer be updating or adding improvements to the game. Sorry about that.</h3>
-			<i>Last updated 3/25 7:20 PM PST</i>
-			<h3>So... it's gone. For good.</h3>
-			My "Friday Night Funkin'" Scratch project has recently been banned from being mass reported, and... Scratch Team has decided to reject it and temp-ban me for 3 days. Scratch Team, what is wrong with it other than "it's inappropriate"? I've tried contacting them about it, but I have recieved no response or clarification on exactly what went wrong, despite me being willing to change anything. I don't understand why <i>my project</i> seems to be the only one having this issue, and everyone else can just reupload it fine and get much, much more views than I had.
-			<br>What's strange is that they <i>put it up</i> for like 5 seconds before they took it down? I don't know...</br>
-			<br>
-			This project has been nothing but headaches, and if I never get to upload it again, there is no use in updating it. <b>I will be completely stopping development unless I find a way to get my project re-approved.</b> There is literally nothing I can do about this, unfortunately.<br>
-			<br>
-			However, <b>this isn't the end of support for any mods or reuploads!</b> I will continue to answer any modding questions you may have about the game. I just won't be updating it. <a href="https://scratch.mit.edu/users/cabalex/">Ask on my profile, and refer anyone who asks there.</a> I'm willing to answer any and all questions you have about the game's internals, besides "can you do this for me", and things already explained in my existing guides.
-			<br></br>
-			<br></br><div style="line-height: 3em"><b><a href="https://ninja-muffin24.itch.io/funkin" style="text-decoration: none; color:white; padding:0.5em; background-color:#ff4d5c; margin-top: 3em; margin-bottom:1em; border-radius:0.25em"><span class="material-icons">videogame_asset</span> Play the original game on itch.io</a> <a href="https://cabalex.github.io/fnf-song-converter/downloads" style="text-decoration: none; color:white; padding:0.5em; background-color:#0fbd8c; margin-top: 3em; margin-bottom:1em; border-radius:0.25em"><span class="material-icons">sports_esports</span> Play my game via Turbowarp</a> <a href="https://cabalex.github.io/fnf-song-converter/downloads" style="text-decoration: none; color:white; padding:0.5em; background-color:#4d97ff; margin-top: 3em; margin-bottom:1em; border-radius:0.25em"><span class="material-icons">get_app</span> Download the .sb3 file for use offline</a></b></div>
-			<br></br>
-			<i>Note: If you're going to reupload or archive my project without making any significant changes, it'd be nice if you credited me in some way in your Notes and Credits section. Thanks!</i>
-			<h2><span class="material-icons">help</span> Some quick QnA:</h2>
-			<h3><span class="material-icons">question_answer</span> Why was it taken down? Did Scratch Team see it?</h3>
-			<b>It was taken down due to mass reporting, but apparently Scratch Team agreed that the project is "inappropriate".</b> I have asked for clarification, but I have since recieved no response.
-			<h3><span class="material-icons">question_answer</span> Can't you just reupload it? What's the big deal?</h3>
-			<b>That will get my account <i>literally banned</i>. No joke.</b> I've already been banned 3 days for reuploading it.
-			<h3><span class="material-icons">question_answer</span> Can I reupload it? I see you linked a .sb3 file.</h3>
-			<b>Yes, though if you're not making any significant changes to the gameplay, I'd like it if you credited me.</b> I don't have a problem with people reuploading my stuff, but if you're just directly copying it to act as an archive, please credit my work. I spent a lot of time on it, and if you don't put it near the top of the Notes and Credits section, people won't see it. Also, I've seen people have their own projects taken down for not crediting me there, so... take with that what you will. <b>Also, if you are directly reuploading my project, please don't modify my watermarks to add your own name.</b> I mean, if you're not making any changes, it seems kinda silly, right?
-			<br><b><a href="https://scratch.mit.edu/projects/492327181/">This project is a good example of how credit should be given.</a></b></br>
-			<h3><span class="material-icons">question_answer</span> Why can't you just keep updating it and let others upload it? I want Week 7 / a level editor / modded songs / etc...</h3>
-			<b>There is no point in updating a game that is completely my work that I can't even post on my profile.</b> I hope you understand.<br>However, if anyone else is willing to make these modifications, I'll gladly support them in <a href="https://scratch.mit.edu/studios/29088650/">my FNF Remix studio</a>.
-			<h3><span class="material-icons">question_answer</span> Why was it taken down???</h3>
-			<b>Your guess is as good as mine.</b> All I get from Scratch Team is "it is inappropriate for the Scratch website".
-			<h3><span class="material-icons">question_answer</span> I want to support you and your project. How can I do that?</h3>
-			<b>Really, all I ask is that you properly credit my work when it is needed (and follow me if you want).</b> If people are passing it off as their own, or just forgetting to credit me, give them a friendly heads-up. I love to see what people do with my stuff, so remix it and add your own flair!
-			<br></br>
-			<br><b>Thank you for playing my game. It's sad to see this project will never see the light of day under official sources, probably ever again, but there is not much I can do. I will still continue to provide support and feedback for anyone who is trying to mod the game, but I cannot provide any further development or mods, including Week 7.</b></br>
-		</div>
-		<div id="warningNotice" style="background-color: #0fbd8c; padding: 1em; margin-top:4em; color: white; left:0; border-radius:0.25em; display: none">
-			Thanks for reading all the way through! As a thank you, I'd like to invite you to test out the Friday Night Funkin Extras project I've been working on.
-			<br></br>
-			<a href="https://turbowarp.org/493230969" style="text-decoration: none; color:black; padding:0.5em; background-color:white; margin-top: 3em; margin-bottom:1em; border-radius:0.25em"><span class="material-icons">sports_esports</span> Play it on Turbowarp</a>
-			<br></br>
-			If you have any thoughts, make sure to comment on my profile about it. I read every message!
-		</div>
-	</body>
+    <div id="topBar" style="background-color: #4d97ff; width: 100%; height: 50px; align-items: center; display: flex; flex-direction: row; position:fixed; top: 0; left: 0">
+      <ul style="list-style: none; display: flex; flex-direction: row; align-items: center; padding-left:0">
+        <li class="heading" style="padding: 1em">
+          <a style="color: #ffffff; text-decoration: none; background-color: #0fbd8c; padding: 1em" href="https://cabalex.github.io"><b>cabalex.github.io</b></a>
+        </li>
+        <li>
+          <a href="https://scratch.mit.edu"><image src="https://scratch.mit.edu/images/logo_sm.png" height="40px"></image></a>
+        </li>
+        <li class="heading" style="padding: 1em">
+          <a style="color: #ffffff; text-decoration: none" href="https://cabalex.github.io/fnf-song-converter"><b>FNF Scratch song converter</b></a>
+        </li>
+    </div>
+    <br></br>
+    <br></br>
+    <div class="banner-outer banner-danger"><div class="flex-row inner banner-inner"><span class="banner-text"><span>Your Scratch account has been temporarily blocked for resharing a censored project without making changes to ensure it follows the Community Guidelines. When your project was censored, you received a notification from the Scratch Team describing what aspects of the project broke our Community Guidelines. It is important to make changes to ensure to follows the Community Guidelines before resharing. Please read the Community Guidelines below for more information. Your account will be automatically unblocked on March 22, 2021, 4:03 p.m.<br><br>For project Friday Night Funkin':<br><br>The Scratch Team has removed this project because it is inappropriate for the Scratch website. Scratch is for kids ages 8 and up, so it's important that everything shared is appropriate for all ages. - March 19, 2021, 3:21 p.m.</span></span></div></div>
+    <div style="padding-top: 1em; padding-bottom: 2em; padding-left: 1em; padding-right: 1em">
+      <h3 style="text-decoration: none; color:white; padding:0.5em; background-color:#ef4d5c; margin-top: 3em; margin-bottom:1em; border-radius:0.25em"><span class="material-icons">warning</span> For now, <u>all plans to continue development of the base game and additional mods have been cancelled/put on hold.</u> I will no longer be updating or adding improvements to the game. Sorry about that.</h3>
+      <i>Last updated 3/25 7:20 PM PST</i>
+      <h3>So... it's gone. For good.</h3>
+      My "Friday Night Funkin'" Scratch project has recently been banned from being mass reported, and... Scratch Team has decided to reject it and temp-ban me for 3 days. Scratch Team, what is wrong with it other than "it's inappropriate"? I've tried contacting them about it, but I have recieved no response or clarification on exactly what went wrong, despite me being willing to change anything. I don't understand why <i>my project</i> seems to be the only one having this issue, and everyone else can just reupload it fine and get much, much more views than I had.
+      <br>What's strange is that they <i>put it up</i> for like 5 seconds before they took it down? I don't know...</br>
+      <br>
+      This project has been nothing but headaches, and if I never get to upload it again, there is no use in updating it. <b>I will be completely stopping development unless I find a way to get my project re-approved.</b> There is literally nothing I can do about this, unfortunately.<br>
+      <br>
+      However, <b>this isn't the end of support for any mods or reuploads!</b> I will continue to answer any modding questions you may have about the game. I just won't be updating it. <a href="https://scratch.mit.edu/users/cabalex/">Ask on my profile, and refer anyone who asks there.</a> I'm willing to answer any and all questions you have about the game's internals, besides "can you do this for me", and things already explained in my existing guides.
+      <br></br>
+      <br></br><div style="line-height: 3em"><b><a href="https://ninja-muffin24.itch.io/funkin" style="text-decoration: none; color:white; padding:0.5em; background-color:#ff4d5c; margin-top: 3em; margin-bottom:1em; border-radius:0.25em"><span class="material-icons">videogame_asset</span> Play the original game on itch.io</a> <a href="https://cabalex.github.io/fnf-song-converter/downloads" style="text-decoration: none; color:white; padding:0.5em; background-color:#0fbd8c; margin-top: 3em; margin-bottom:1em; border-radius:0.25em"><span class="material-icons">sports_esports</span> Play my game via Turbowarp</a> <a href="https://cabalex.github.io/fnf-song-converter/downloads" style="text-decoration: none; color:white; padding:0.5em; background-color:#4d97ff; margin-top: 3em; margin-bottom:1em; border-radius:0.25em"><span class="material-icons">get_app</span> Download the .sb3 file for use offline</a></b></div>
+      <br></br>
+      <i>Note: If you're going to reupload or archive my project without making any significant changes, it'd be nice if you credited me in some way in your Notes and Credits section. Thanks!</i>
+      <h2><span class="material-icons">help</span> Some quick QnA:</h2>
+      <h3><span class="material-icons">question_answer</span> Why was it taken down? Did Scratch Team see it?</h3>
+      <b>It was taken down due to mass reporting, but apparently Scratch Team agreed that the project is "inappropriate".</b> I have asked for clarification, but I have since recieved no response.
+      <h3><span class="material-icons">question_answer</span> Can't you just reupload it? What's the big deal?</h3>
+      <b>That will get my account <i>literally banned</i>. No joke.</b> I've already been banned 3 days for reuploading it.
+      <h3><span class="material-icons">question_answer</span> Can I reupload it? I see you linked a .sb3 file.</h3>
+      <b>Yes, though if you're not making any significant changes to the gameplay, I'd like it if you credited me.</b> I don't have a problem with people reuploading my stuff, but if you're just directly copying it to act as an archive, please credit my work. I spent a lot of time on it, and if you don't put it near the top of the Notes and Credits section, people won't see it. Also, I've seen people have their own projects taken down for not crediting me there, so... take with that what you will. <b>Also, if you are directly reuploading my project, please don't modify my watermarks to add your own name.</b> I mean, if you're not making any changes, it seems kinda silly, right?
+      <br><b><a href="https://scratch.mit.edu/projects/492327181/">This project is a good example of how credit should be given.</a></b></br>
+      <h3><span class="material-icons">question_answer</span> Why can't you just keep updating it and let others upload it? I want Week 7 / a level editor / modded songs / etc...</h3>
+      <b>There is no point in updating a game that is completely my work that I can't even post on my profile.</b> I hope you understand.<br>However, if anyone else is willing to make these modifications, I'll gladly support them in <a href="https://scratch.mit.edu/studios/29088650/">my FNF Remix studio</a>.
+      <h3><span class="material-icons">question_answer</span> Why was it taken down???</h3>
+      <b>Your guess is as good as mine.</b> All I get from Scratch Team is "it is inappropriate for the Scratch website".
+      <h3><span class="material-icons">question_answer</span> I want to support you and your project. How can I do that?</h3>
+      <b>Really, all I ask is that you properly credit my work when it is needed (and follow me if you want).</b> If people are passing it off as their own, or just forgetting to credit me, give them a friendly heads-up. I love to see what people do with my stuff, so remix it and add your own flair!
+      <br></br>
+      <br><b>Thank you for playing my game. It's sad to see this project will never see the light of day under official sources, probably ever again, but there is not much I can do. I will still continue to provide support and feedback for anyone who is trying to mod the game, but I cannot provide any further development or mods, including Week 7.</b></br>
+    </div>
+    <div id="warningNotice" style="background-color: #0fbd8c; padding: 1em; margin-top:4em; color: white; left:0; border-radius:0.25em; display: none">
+      Thanks for reading all the way through! As a thank you, I'd like to invite you to test out the Friday Night Funkin Extras project I've been working on.
+      <br></br>
+      <a href="https://turbowarp.org/493230969" style="text-decoration: none; color:black; padding:0.5em; background-color:white; margin-top: 3em; margin-bottom:1em; border-radius:0.25em"><span class="material-icons">sports_esports</span> Play it on Turbowarp</a>
+      <br></br>
+      If you have any thoughts, make sure to comment on my profile about it. I read every message!
+    </div>
+  </body>
 </html>


### PR DESCRIPTION
Why stick with just white mode, also allow dark mode!
I was using this at night (maybe others do too or prefer dark mode) and I had an idea of adding dark mode

How to activate:
There's no button to activate it, it's based on the preference you set on your device
All links still connect to https://cabalex.github.io/fnf-song-converter

Proof of concept page [here](https://frostzzone.github.io/fnf-song-converter/)

It may be called:
 - night mode
 - dark mode
Works on:
 - all devices with a dark mode option
 
Android Examples:
![Android-Download-Page](https://user-images.githubusercontent.com/65735427/138726094-6600a467-be01-428c-b587-38873503d1d3.jpg)
![Android-Main](https://user-images.githubusercontent.com/65735427/138726099-4b98db2d-8405-488a-91ed-7828ffbe846d.jpg)
![Android-Guide](https://user-images.githubusercontent.com/65735427/138726739-7c289e6d-3680-4cb1-9b4f-f9bf98145f58.jpg)

Windows examples:
![Concept-Light](https://user-images.githubusercontent.com/65735427/138730149-d97ba3fe-8cdd-4630-ab8f-e161f30c1f70.png)
![Concept-Dark](https://user-images.githubusercontent.com/65735427/138730127-a94cc8db-e0f9-49c1-b567-a78e08643162.png)